### PR TITLE
Fix bug in create habit hoover

### DIFF
--- a/front/src/Components/Habit.js
+++ b/front/src/Components/Habit.js
@@ -242,8 +242,9 @@ const Habit = (props) => {
                                                                             {
                                                                                 area.subareas.map((subarea, i) => {
                                                                                     return (
+                                                                                        //Hay un error en sub-area :hover al momento de crear un nuevo hábito ya que si se ha seleccionado un habito en el hoover se sobreescibe el nombre
                                                                                         <div className={`sub-area ${inputs.subarea === area.codigos[i] ? 'active' : ''}`} key={'subarea-' + subarea} onClick={() => setInput(area.codigos[i], 'subarea')}>
-                                                                                            <span>{subarea}</span>
+                                                                                            <span className={`${cond} ? 'white' : ''}`}>{subarea}</span>
                                                                                             <div className="icon fit">
                                                                                                 {icons[area.codigos[i] - 1]}
                                                                                             </div>


### PR DESCRIPTION
Hay un error en sub-area :hover al momento de crear un nuevo hábito ya que si se ha seleccionado un habito en el hoover se sobreescibe el nombre. Pueden solucionarlo con un condicional para saber si ya esta selecionado un area similar al div padre.